### PR TITLE
fix: nested <a> tags and forwardRef warning in nav

### DIFF
--- a/src/components/custom/custom-navbar.tsx
+++ b/src/components/custom/custom-navbar.tsx
@@ -145,7 +145,9 @@ export function Navbar() {
           href="/"
           target="_self"
         >
-          <NavigationMenuLink>{t('navbar.home')}</NavigationMenuLink>
+          <NavigationMenuLink asChild>
+            <span>{t('navbar.home')}</span>
+          </NavigationMenuLink>
         </CustomButton>
       </NavigationMenuItem>
 
@@ -263,11 +265,11 @@ export function Navbar() {
 }
 
 const ListItem = React.forwardRef<
-  React.ElementRef<'a'>,
+  React.ElementRef<'li'>,
   React.ComponentPropsWithoutRef<'a'>
->(({ className, title, children, href }) => {
+>(({ className, title, children, href }, ref) => {
   return (
-    <li>
+    <li ref={ref}>
       <CustomButton
         className={cn(
           'max-w-[130px] justify-start text-left h-auto p-3 flex-col items-start',

--- a/src/components/custom/social-bar.tsx
+++ b/src/components/custom/social-bar.tsx
@@ -87,10 +87,12 @@ export default function SocialBar({ className }: SocialBarProps) {
               className="rounded-full h-8 w-8 p-5"
               href={user[link.url]}
             >
-              <HoverCardTrigger>
-                <CustomButton.Icon className="text-2xl text-black dark:text-white">
-                  {link.icon}
-                </CustomButton.Icon>
+              <HoverCardTrigger asChild>
+                <span>
+                  <CustomButton.Icon className="text-2xl text-black dark:text-white">
+                    {link.icon}
+                  </CustomButton.Icon>
+                </span>
               </HoverCardTrigger>
             </CustomButton>
             <HoverCardContent className="w-80">


### PR DESCRIPTION
## Summary
- `CustomButton` renders an outer `<Link>` (`<a>`) when given `href`. Wrapping a Radix trigger that also defaults to `<a>` (`HoverCardTrigger` in the social icons, `NavigationMenuLink` for the Home nav item) produced invalid `<a><a></a></a>` markup and a React dev warning. Fixed by giving those triggers `asChild` with a plain `<span>`, so only the outer anchor remains — same click/hover behavior, valid HTML.
- `ListItem` in `custom-navbar.tsx` used `React.forwardRef` but only destructured `props`, dropping the `ref` param entirely (React warning: "forwardRef render functions accept exactly two parameters"). Now forwards `ref` to the `<li>`.

Verified: 0 console errors on `/`, `/about`, `/projects` (was 3 warnings before, on every page, since Sidebar+Header+SocialBar render on all of them).

## Test plan
- [x] `npm run build` succeeds
- [x] Playwright console-error check on Home/About/Projects: 0 errors (previously nested-`<a>` + forwardRef warnings on all three)
- [x] Visual check: nav bar and social icon row render identically (screenshots compared before/after)