### PR TITLE
feat: animated particle background + more motion (futuristic look)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "react-tsparticles": "^2.12.2",
         "react-zoom-pan-pinch": "^3.7.0",
         "tailwind-merge": "^3.3.1",
+        "tsparticles-slim": "^2.12.0",
         "typewriter-effect": "^2.21.0",
         "zustand": "^5.0.1"
       },
@@ -6345,6 +6346,36 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsparticles-basic": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-basic/-/tsparticles-basic-2.12.0.tgz",
+      "integrity": "sha512-pN6FBpL0UsIUXjYbiui5+IVsbIItbQGOlwyGV55g6IYJBgdTNXgFX0HRYZGE9ZZ9psEXqzqwLM37zvWnb5AG9g==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0",
+        "tsparticles-move-base": "^2.12.0",
+        "tsparticles-shape-circle": "^2.12.0",
+        "tsparticles-updater-color": "^2.12.0",
+        "tsparticles-updater-opacity": "^2.12.0",
+        "tsparticles-updater-out-modes": "^2.12.0",
+        "tsparticles-updater-size": "^2.12.0"
+      }
+    },
     "node_modules/tsparticles-engine": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/tsparticles-engine/-/tsparticles-engine-2.12.0.tgz",
@@ -6366,6 +6397,400 @@
       ],
       "hasInstallScript": true,
       "license": "MIT"
+    },
+    "node_modules/tsparticles-interaction-external-attract": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-attract/-/tsparticles-interaction-external-attract-2.12.0.tgz",
+      "integrity": "sha512-0roC6D1QkFqMVomcMlTaBrNVjVOpyNzxIUsjMfshk2wUZDAvTNTuWQdUpmsLS4EeSTDN3rzlGNnIuuUQqyBU5w==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-bounce": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bounce/-/tsparticles-interaction-external-bounce-2.12.0.tgz",
+      "integrity": "sha512-MMcqKLnQMJ30hubORtdq+4QMldQ3+gJu0bBYsQr9BsThsh8/V0xHc1iokZobqHYVP5tV77mbFBD8Z7iSCf0TMQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-bubble": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bubble/-/tsparticles-interaction-external-bubble-2.12.0.tgz",
+      "integrity": "sha512-5kImCSCZlLNccXOHPIi2Yn+rQWTX3sEa/xCHwXW19uHxtILVJlnAweayc8+Zgmb7mo0DscBtWVFXHPxrVPFDUA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-connect": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-connect/-/tsparticles-interaction-external-connect-2.12.0.tgz",
+      "integrity": "sha512-ymzmFPXz6AaA1LAOL5Ihuy7YSQEW8MzuSJzbd0ES13U8XjiU3HlFqlH6WGT1KvXNw6WYoqrZt0T3fKxBW3/C3A==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-grab": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-grab/-/tsparticles-interaction-external-grab-2.12.0.tgz",
+      "integrity": "sha512-iQF/A947hSfDNqAjr49PRjyQaeRkYgTYpfNmAf+EfME8RsbapeP/BSyF6mTy0UAFC0hK2A2Hwgw72eT78yhXeQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-pause": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-pause/-/tsparticles-interaction-external-pause-2.12.0.tgz",
+      "integrity": "sha512-4SUikNpsFROHnRqniL+uX2E388YTtfRWqqqZxRhY0BrijH4z04Aii3YqaGhJxfrwDKkTQlIoM2GbFT552QZWjw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-push": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-push/-/tsparticles-interaction-external-push-2.12.0.tgz",
+      "integrity": "sha512-kqs3V0dgDKgMoeqbdg+cKH2F+DTrvfCMrPF1MCCUpBCqBiH+TRQpJNNC86EZYHfNUeeLuIM3ttWwIkk2hllR/Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-remove": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-remove/-/tsparticles-interaction-external-remove-2.12.0.tgz",
+      "integrity": "sha512-2eNIrv4m1WB2VfSVj46V2L/J9hNEZnMgFc+A+qmy66C8KzDN1G8aJUAf1inW8JVc0lmo5+WKhzex4X0ZSMghBg==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-repulse": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-repulse/-/tsparticles-interaction-external-repulse-2.12.0.tgz",
+      "integrity": "sha512-rSzdnmgljeBCj5FPp4AtGxOG9TmTsK3AjQW0vlyd1aG2O5kSqFjR+FuT7rfdSk9LEJGH5SjPFE6cwbuy51uEWA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-external-slow": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-slow/-/tsparticles-interaction-external-slow-2.12.0.tgz",
+      "integrity": "sha512-2IKdMC3om7DttqyroMtO//xNdF0NvJL/Lx7LDo08VpfTgJJozxU+JAUT8XVT7urxhaDzbxSSIROc79epESROtA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-particles-attract": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-attract/-/tsparticles-interaction-particles-attract-2.12.0.tgz",
+      "integrity": "sha512-Hl8qwuwF9aLq3FOkAW+Zomu7Gb8IKs6Y3tFQUQScDmrrSCaeRt2EGklAiwgxwgntmqzL7hbMWNx06CHHcUQKdQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-particles-collisions": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-collisions/-/tsparticles-interaction-particles-collisions-2.12.0.tgz",
+      "integrity": "sha512-Se9nPWlyPxdsnHgR6ap4YUImAu3W5MeGKJaQMiQpm1vW8lSMOUejI1n1ioIaQth9weKGKnD9rvcNn76sFlzGBA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-interaction-particles-links": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-links/-/tsparticles-interaction-particles-links-2.12.0.tgz",
+      "integrity": "sha512-e7I8gRs4rmKfcsHONXMkJnymRWpxHmeaJIo4g2NaDRjIgeb2AcJSWKWZvrsoLnm7zvaf/cMQlbN6vQwCixYq3A==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-move-base": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-move-base/-/tsparticles-move-base-2.12.0.tgz",
+      "integrity": "sha512-oSogCDougIImq+iRtIFJD0YFArlorSi8IW3HD2gO3USkH+aNn3ZqZNTqp321uB08K34HpS263DTbhLHa/D6BWw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-move-parallax": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-move-parallax/-/tsparticles-move-parallax-2.12.0.tgz",
+      "integrity": "sha512-58CYXaX8Ih5rNtYhpnH0YwU4Ks7gVZMREGUJtmjhuYN+OFr9FVdF3oDIJ9N6gY5a5AnAKz8f5j5qpucoPRcYrQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-particles.js": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-particles.js/-/tsparticles-particles.js-2.12.0.tgz",
+      "integrity": "sha512-LyOuvYdhbUScmA4iDgV3LxA0HzY1DnOwQUy3NrPYO393S2YwdDjdwMod6Btq7EBUjg9FVIh+sZRizgV5elV2dg==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-plugin-easing-quad": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-plugin-easing-quad/-/tsparticles-plugin-easing-quad-2.12.0.tgz",
+      "integrity": "sha512-2mNqez5pydDewMIUWaUhY5cNQ80IUOYiujwG6qx9spTq1D6EEPLbRNAEL8/ecPdn2j1Um3iWSx6lo340rPkv4Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-circle": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-circle/-/tsparticles-shape-circle-2.12.0.tgz",
+      "integrity": "sha512-L6OngbAlbadG7b783x16ns3+SZ7i0SSB66M8xGa5/k+YcY7zm8zG0uPt1Hd+xQDR2aNA3RngVM10O23/Lwk65Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-image": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-image/-/tsparticles-shape-image-2.12.0.tgz",
+      "integrity": "sha512-iCkSdUVa40DxhkkYjYuYHr9MJGVw+QnQuN5UC+e/yBgJQY+1tQL8UH0+YU/h0GHTzh5Sm+y+g51gOFxHt1dj7Q==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-line": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-line/-/tsparticles-shape-line-2.12.0.tgz",
+      "integrity": "sha512-RcpKmmpKlk+R8mM5wA2v64Lv1jvXtU4SrBDv3vbdRodKbKaWGGzymzav1Q0hYyDyUZgplEK/a5ZwrfrOwmgYGA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-polygon": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-polygon/-/tsparticles-shape-polygon-2.12.0.tgz",
+      "integrity": "sha512-5YEy7HVMt1Obxd/jnlsjajchAlYMr9eRZWN+lSjcFSH6Ibra7h59YuJVnwxOxAobpijGxsNiBX0PuGQnB47pmA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-square": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-square/-/tsparticles-shape-square-2.12.0.tgz",
+      "integrity": "sha512-33vfajHqmlODKaUzyPI/aVhnAOT09V7nfEPNl8DD0cfiNikEuPkbFqgJezJuE55ebtVo7BZPDA9o7GYbWxQNuw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-star": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-star/-/tsparticles-shape-star-2.12.0.tgz",
+      "integrity": "sha512-4sfG/BBqm2qBnPLASl2L5aBfCx86cmZLXeh49Un+TIR1F5Qh4XUFsahgVOG0vkZQa+rOsZPEH04xY5feWmj90g==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-shape-text": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-shape-text/-/tsparticles-shape-text-2.12.0.tgz",
+      "integrity": "sha512-v2/FCA+hyTbDqp2ymFOe97h/NFb2eezECMrdirHWew3E3qlvj9S/xBibjbpZva2gnXcasBwxn0+LxKbgGdP0rA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-slim": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-slim/-/tsparticles-slim-2.12.0.tgz",
+      "integrity": "sha512-27w9aGAAAPKHvP4LHzWFpyqu7wKyulayyaZ/L6Tuuejy4KP4BBEB4rY5GG91yvAPsLtr6rwWAn3yS+uxnBDpkA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-basic": "^2.12.0",
+        "tsparticles-engine": "^2.12.0",
+        "tsparticles-interaction-external-attract": "^2.12.0",
+        "tsparticles-interaction-external-bounce": "^2.12.0",
+        "tsparticles-interaction-external-bubble": "^2.12.0",
+        "tsparticles-interaction-external-connect": "^2.12.0",
+        "tsparticles-interaction-external-grab": "^2.12.0",
+        "tsparticles-interaction-external-pause": "^2.12.0",
+        "tsparticles-interaction-external-push": "^2.12.0",
+        "tsparticles-interaction-external-remove": "^2.12.0",
+        "tsparticles-interaction-external-repulse": "^2.12.0",
+        "tsparticles-interaction-external-slow": "^2.12.0",
+        "tsparticles-interaction-particles-attract": "^2.12.0",
+        "tsparticles-interaction-particles-collisions": "^2.12.0",
+        "tsparticles-interaction-particles-links": "^2.12.0",
+        "tsparticles-move-base": "^2.12.0",
+        "tsparticles-move-parallax": "^2.12.0",
+        "tsparticles-particles.js": "^2.12.0",
+        "tsparticles-plugin-easing-quad": "^2.12.0",
+        "tsparticles-shape-circle": "^2.12.0",
+        "tsparticles-shape-image": "^2.12.0",
+        "tsparticles-shape-line": "^2.12.0",
+        "tsparticles-shape-polygon": "^2.12.0",
+        "tsparticles-shape-square": "^2.12.0",
+        "tsparticles-shape-star": "^2.12.0",
+        "tsparticles-shape-text": "^2.12.0",
+        "tsparticles-updater-color": "^2.12.0",
+        "tsparticles-updater-life": "^2.12.0",
+        "tsparticles-updater-opacity": "^2.12.0",
+        "tsparticles-updater-out-modes": "^2.12.0",
+        "tsparticles-updater-rotate": "^2.12.0",
+        "tsparticles-updater-size": "^2.12.0",
+        "tsparticles-updater-stroke-color": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-color": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-color/-/tsparticles-updater-color-2.12.0.tgz",
+      "integrity": "sha512-KcG3a8zd0f8CTiOrylXGChBrjhKcchvDJjx9sp5qpwQK61JlNojNCU35xoaSk2eEHeOvFjh0o3CXWUmYPUcBTQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-life": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-life/-/tsparticles-updater-life-2.12.0.tgz",
+      "integrity": "sha512-J7RWGHAZkowBHpcLpmjKsxwnZZJ94oGEL2w+wvW1/+ZLmAiFFF6UgU0rHMC5CbHJT4IPx9cbkYMEHsBkcRJ0Bw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-opacity": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-opacity/-/tsparticles-updater-opacity-2.12.0.tgz",
+      "integrity": "sha512-YUjMsgHdaYi4HN89LLogboYcCi1o9VGo21upoqxq19yRy0hRCtx2NhH22iHF/i5WrX6jqshN0iuiiNefC53CsA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-out-modes": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-out-modes/-/tsparticles-updater-out-modes-2.12.0.tgz",
+      "integrity": "sha512-owBp4Gk0JNlSrmp12XVEeBroDhLZU+Uq3szbWlHGSfcR88W4c/0bt0FiH5bHUqORIkw+m8O56hCjbqwj69kpOQ==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-rotate": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-rotate/-/tsparticles-updater-rotate-2.12.0.tgz",
+      "integrity": "sha512-waOFlGFmEZOzsQg4C4VSejNVXGf4dMf3fsnQrEROASGf1FCd8B6WcZau7JtXSTFw0OUGuk8UGz36ETWN72DkCw==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-size": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-size/-/tsparticles-updater-size-2.12.0.tgz",
+      "integrity": "sha512-B0yRdEDd/qZXCGDL/ussHfx5YJ9UhTqNvmS5X2rR2hiZhBAE2fmsXLeWkdtF2QusjPeEqFDxrkGiLOsh6poqRA==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
+    },
+    "node_modules/tsparticles-updater-stroke-color": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/tsparticles-updater-stroke-color/-/tsparticles-updater-stroke-color-2.12.0.tgz",
+      "integrity": "sha512-MPou1ZDxsuVq6SN1fbX+aI5yrs6FyP2iPCqqttpNbWyL+R6fik1rL0ab/x02B57liDXqGKYomIbBQVP3zUTW1A==",
+      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
+      "license": "MIT",
+      "dependencies": {
+        "tsparticles-engine": "^2.12.0"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-tsparticles": "^2.12.2",
     "react-zoom-pan-pinch": "^3.7.0",
     "tailwind-merge": "^3.3.1",
+    "tsparticles-slim": "^2.12.0",
     "typewriter-effect": "^2.21.0",
     "zustand": "^5.0.1"
   },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,5 @@
 import { AnimatePresence } from 'framer-motion'
+import { lazy, Suspense } from 'react'
 import { I18nextProvider } from 'react-i18next'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { ThemeProvider } from './components/providers/ThemeProvider'
@@ -7,12 +8,29 @@ import { About } from './pages/About'
 import { Home } from './pages/Home'
 import { Projects } from './pages/Projects'
 
+const ParticlesBackground = lazy(() =>
+  import('./components/custom/particles-background').then(mod => ({
+    default: mod.ParticlesBackground,
+  }))
+)
+
 function App() {
   return (
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <I18nextProvider defaultNS={'translation'} i18n={i18n}>
         <AnimatePresence mode="wait">
-          <div className="leading-5 bg-gradient-to-br from-mainColor/5 via-background to-mainColor/5">
+          <div className="relative min-h-screen overflow-x-hidden leading-5">
+            <div
+              aria-hidden
+              className="pointer-events-none fixed -top-40 -right-40 z-0 h-[36rem] w-[36rem] rounded-full bg-mainColor/25 blur-[120px] dark:bg-mainColor/20"
+            />
+            <div
+              aria-hidden
+              className="pointer-events-none fixed -bottom-40 -left-40 z-0 h-[36rem] w-[36rem] rounded-full bg-lightMainColor/20 blur-[120px] dark:bg-lightMainColor/15"
+            />
+            <Suspense fallback={null}>
+              <ParticlesBackground />
+            </Suspense>
             <BrowserRouter>
               <Routes>
                 <Route

--- a/src/components/custom/custom-button.tsx
+++ b/src/components/custom/custom-button.tsx
@@ -21,7 +21,7 @@ interface CustomButtonProps extends ComponentProps<typeof Button> {
 }
 
 const defaultClassNameButton =
-  'gap-2 border-mainColor bg-transparent text-sm hover:opacity-70 dark:border-mainColor dark:hover:shadow-lightMainColorDark cursor-pointer border-2 rounded-xl'
+  'gap-2 border-mainColor bg-transparent text-sm transition-[opacity,transform] duration-200 ease-out hover:-translate-y-0.5 hover:opacity-70 active:translate-y-0 active:duration-75 dark:border-mainColor dark:hover:shadow-lightMainColorDark cursor-pointer border-2 rounded-xl'
 
 function CustomButton({ href, target, ...props }: CustomButtonProps) {
   if (href) {

--- a/src/components/custom/custom-navbar.tsx
+++ b/src/components/custom/custom-navbar.tsx
@@ -145,7 +145,9 @@ export function Navbar() {
           href="/"
           target="_self"
         >
-          <NavigationMenuLink>{t('navbar.home')}</NavigationMenuLink>
+          <NavigationMenuLink asChild>
+            <span>{t('navbar.home')}</span>
+          </NavigationMenuLink>
         </CustomButton>
       </NavigationMenuItem>
 
@@ -263,11 +265,11 @@ export function Navbar() {
 }
 
 const ListItem = React.forwardRef<
-  React.ElementRef<'a'>,
+  React.ElementRef<'li'>,
   React.ComponentPropsWithoutRef<'a'>
->(({ className, title, children, href }) => {
+>(({ className, title, children, href }, ref) => {
   return (
-    <li>
+    <li ref={ref}>
       <CustomButton
         className={cn(
           'max-w-[130px] justify-start text-left h-auto p-3 flex-col items-start',

--- a/src/components/custom/particles-background.tsx
+++ b/src/components/custom/particles-background.tsx
@@ -1,0 +1,84 @@
+import { useReducedMotion } from 'framer-motion'
+import { useCallback, useEffect, useState } from 'react'
+import Particles from 'react-tsparticles'
+import type { Engine } from 'tsparticles-engine'
+import { loadSlim } from 'tsparticles-slim'
+
+function useIsDark() {
+  const [isDark, setIsDark] = useState(() =>
+    document.documentElement.classList.contains('dark')
+  )
+
+  useEffect(() => {
+    const root = document.documentElement
+    const observer = new MutationObserver(() => {
+      setIsDark(root.classList.contains('dark'))
+    })
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  return isDark
+}
+
+export function ParticlesBackground() {
+  const isDark = useIsDark()
+  const reduceMotion = useReducedMotion()
+
+  const init = useCallback(async (engine: Engine) => {
+    await loadSlim(engine)
+  }, [])
+
+  const particleColor = isDark ? '#3b82f6' : '#2563eb'
+  const linkOpacity = isDark ? 0.25 : 0.15
+  const particleOpacity = isDark ? 0.5 : 0.35
+
+  return (
+    <Particles
+      className="pointer-events-none fixed inset-0 z-0"
+      init={init}
+      options={{
+        fullScreen: { enable: false },
+        background: { color: { value: 'transparent' } },
+        fpsLimit: 60,
+        particles: {
+          color: { value: particleColor },
+          links: {
+            color: particleColor,
+            distance: 140,
+            enable: true,
+            opacity: linkOpacity,
+            width: 1,
+          },
+          move: {
+            enable: !reduceMotion,
+            direction: 'none',
+            outModes: { default: 'out' },
+            random: false,
+            speed: 0.4,
+            straight: false,
+          },
+          number: {
+            density: { enable: true, area: 900 },
+            value: 55,
+          },
+          opacity: { value: particleOpacity },
+          shape: { type: 'circle' },
+          size: { value: { min: 1, max: 2.5 } },
+        },
+        interactivity: {
+          events: {
+            onHover: { enable: !reduceMotion, mode: 'grab' },
+          },
+          modes: {
+            grab: {
+              distance: 160,
+              links: { opacity: isDark ? 0.5 : 0.35 },
+            },
+          },
+        },
+        detectRetina: true,
+      }}
+    />
+  )
+}

--- a/src/components/custom/photo.tsx
+++ b/src/components/custom/photo.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import { twMerge } from 'tailwind-merge'
 import { useUser } from '@/hooks/use-user'
 
@@ -10,6 +10,7 @@ const Photo = ({ className }: PhotoProps) => {
   const {
     user: { profilePicture },
   } = useUser()
+  const reduceMotion = useReducedMotion()
   return (
     <div
       className={twMerge(
@@ -51,10 +52,18 @@ const Photo = ({ className }: PhotoProps) => {
           xmlns="http://www.w3.org/2000/svg"
         >
           <motion.circle
-            animate={{
-              strokeDasharray: ['15 120 25 25', '16 25 92 72', '4 250 22 22'],
-              rotate: [120, 360],
-            }}
+            animate={
+              reduceMotion
+                ? { strokeDasharray: '16 25 92 72' }
+                : {
+                    strokeDasharray: [
+                      '15 120 25 25',
+                      '16 25 92 72',
+                      '4 250 22 22',
+                    ],
+                    rotate: [120, 360],
+                  }
+            }
             className="stroke-mainColor"
             cx="253"
             cy="253"
@@ -63,11 +72,15 @@ const Photo = ({ className }: PhotoProps) => {
             strokeLinecap="round"
             strokeLinejoin="round"
             strokeWidth="4"
-            transition={{
-              duration: 20,
-              repeat: Number.POSITIVE_INFINITY,
-              repeatType: 'reverse',
-            }}
+            transition={
+              reduceMotion
+                ? { duration: 0.3 }
+                : {
+                    duration: 20,
+                    repeat: Number.POSITIVE_INFINITY,
+                    repeatType: 'reverse',
+                  }
+            }
           />
         </motion.svg>
       </motion.div>

--- a/src/components/custom/project-card.tsx
+++ b/src/components/custom/project-card.tsx
@@ -110,7 +110,7 @@ export default function ProjectCard({
   const previewImage = thumbnail || images?.[0]
 
   return (
-    <Card className="transition-shadow hover:shadow-md">
+    <Card className="transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-1 hover:shadow-lg">
       <Section.Root id={title}>
         <Accordion
           className="w-full"

--- a/src/components/custom/social-bar.tsx
+++ b/src/components/custom/social-bar.tsx
@@ -87,10 +87,12 @@ export default function SocialBar({ className }: SocialBarProps) {
               className="rounded-full h-8 w-8 p-5"
               href={user[link.url]}
             >
-              <HoverCardTrigger>
-                <CustomButton.Icon className="text-2xl text-black dark:text-white">
-                  {link.icon}
-                </CustomButton.Icon>
+              <HoverCardTrigger asChild>
+                <span>
+                  <CustomButton.Icon className="text-2xl text-black dark:text-white">
+                    {link.icon}
+                  </CustomButton.Icon>
+                </span>
               </HoverCardTrigger>
             </CustomButton>
             <HoverCardContent className="w-80">

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -206,7 +206,7 @@ export function About() {
             <Section.Content className="flex flex-col gap-2">
               {user.experiences.map((experience, index) => (
                 <motion.div key={index} {...reveal(index)}>
-                  <Card className="relative transition-shadow hover:shadow-md p-6 gap-2 flex flex-col">
+                  <Card className="relative transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-1 hover:shadow-lg p-6 gap-2 flex flex-col">
                     {experience.logo && (
                       <img
                         alt={`${experience.enterprise} logo`}
@@ -276,7 +276,7 @@ export function About() {
             <Section.Content className="space-y-4">
               {user.formations.map((formation, index) => (
                 <motion.div key={index} {...reveal(index)}>
-                  <Card className="transition-shadow hover:shadow-md p-6 gap-2 flex flex-col">
+                  <Card className="transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-1 hover:shadow-lg p-6 gap-2 flex flex-col">
                     <CardHeader className="p-0">
                       <div className="flex w-full items-start justify-between gap-4">
                         <div className="flex flex-1 items-center gap-3">
@@ -383,7 +383,7 @@ export function About() {
               {t('about.certificatesTitle')}
             </Section.Title>
             <Section.Content>
-              <Card className="transition-shadow hover:shadow-md p-6 gap-2 flex flex-col">
+              <Card className="transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-1 hover:shadow-lg p-6 gap-2 flex flex-col">
                 <CardHeader className="p-0">
                   <div className="flex items-center gap-3">
                     <div className="rounded-lg ">
@@ -467,7 +467,7 @@ export function About() {
             <Section.Content className="space-y-4">
               {user.recomendations.map((recomendation, index) => (
                 <motion.div key={recomendation.date} {...reveal(index)}>
-                  <Card className="transition-shadow hover:shadow-md p-6 gap-2 flex flex-col">
+                  <Card className="transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-1 hover:shadow-lg p-6 gap-2 flex flex-col">
                     <CardHeader className="p-0">
                       <div className="flex items-center gap-4">
                         <SectionItem.Avatar


### PR DESCRIPTION
## Summary
- New connected-particle network background (`react-tsparticles`, was an installed-but-unused dependency) + two blurred glow orbs, behind all pages. Lazy-loaded as its own chunk (~40kB gzip) so it doesn't bloat the main bundle. Theme-aware color/opacity, respects `prefers-reduced-motion` (freezes movement instead of unmounting).
- Fixed a z-index stacking bug found while wiring this up: the page wrapper had an opaque `bg-background` with negative-z-index children — CSS always paints negative-z-index descendants behind their own stacking context's background, so the effect was invisible regardless of z-index value. Removed the redundant background (body already provides it) and used `z-0` siblings ordered by DOM position instead.
- Hover-lift (transform-based, not layout props) on buttons and project/experience/education cards for tactile feedback.
- Fixed missing `prefers-reduced-motion` handling on the avatar's infinite rotating orbit ring.

Addresses feedback that the previous flat background was less nice than before, and a request for more motion / a more futuristic feel.

## Depends on
This branch is based on `main` and additionally cherry-picks the nested-`<a>`/forwardRef fix from #31 so it can be tested cleanly on its own (console-error-free). If #31 merges first, this will show as already included with no conflict.

## Test plan
- [x] `npm run build` succeeds; particles code-split into its own lazy chunk
- [x] Playwright console-error check on `/`, `/about`, `/projects`: 0 errors
- [x] Visual check light + dark on all three pages (particles/glow visible, text contrast fine)
- [x] `prefers-reduced-motion: reduce` emulated: particles render static (no movement/hover-grab), avatar ring static, no errors