### PR TITLE
feat(projects): infinite-scroll list + per-project detail pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 .next
 next-env.d.ts
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*

--- a/src/Translation/English/translation.json
+++ b/src/Translation/English/translation.json
@@ -44,6 +44,8 @@
   "projects.clear": "Clear",
 
   "projects.hasImage": "Has image",
+  "projects.backToProjects": "Back to projects",
+  "projects.notFound": "Project not found",
 
   "projectCard.technologiesUsed": "Technologies Used",
   "projectCard.viewGitHub": "View GitHub",

--- a/src/Translation/Portuguese/translation.json
+++ b/src/Translation/Portuguese/translation.json
@@ -43,6 +43,8 @@
   "projects.clear": "Limpar",
   "projects.search": "Pesquisar por nome...",
   "projects.hasImage": "Possui imagem",
+  "projects.backToProjects": "Voltar para projetos",
+  "projects.notFound": "Projeto não encontrado",
 
   "projectCard.technologiesUsed": "Tecnologias Utilizadas",
   "projectCard.viewGitHub": "Ver GitHub",

--- a/src/app/projects/[slug]/not-found.tsx
+++ b/src/app/projects/[slug]/not-found.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { FolderOpen, RotateCcw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import Container from '@/components/custom/container'
+import { CustomButton } from '@/components/custom/custom-button'
+import Sidebar from '@/components/custom/custom-sidebar'
+import Header from '@/components/custom/header'
+import Section from '@/components/custom/section'
+import { Card, CardContent } from '@/components/ui/card'
+
+export default function NotFound() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="min-h-screen text-foreground">
+      <Sidebar />
+      <Container>
+        <Header />
+        <Section.Root>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="py-8 text-center">
+                <FolderOpen className="mx-auto mb-4 h-12 w-12 !text-mainColor" />
+                <h3 className="mb-2 text-lg font-medium text-foreground">
+                  {t('projects.notFound')}
+                </h3>
+                <CustomButton href="/projects">
+                  <CustomButton.Icon>
+                    <RotateCcw />
+                  </CustomButton.Icon>
+                  <CustomButton.Label>
+                    {t('projects.backToProjects')}
+                  </CustomButton.Label>
+                </CustomButton>
+              </div>
+            </CardContent>
+          </Card>
+        </Section.Root>
+      </Container>
+    </div>
+  )
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { ProjectDetail } from '@/views/ProjectDetail'
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export default async function Page({ params }: PageProps) {
+  const { slug } = await params
+  return <ProjectDetail slug={slug} />
+}

--- a/src/components/custom/carousel-pagination.tsx
+++ b/src/components/custom/carousel-pagination.tsx
@@ -1,13 +1,7 @@
-import {
-  ChevronLeft,
-  ChevronRight,
-  ChevronsLeft,
-  ChevronsRight,
-} from 'lucide-react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import type React from 'react'
 import type { CarouselApi } from '@/components/ui/carousel'
-import { Pagination, PaginationContent } from '@/components/ui/pagination'
-import { CustomButton } from './custom-button'
+import { cn } from '@/lib/utils/cn'
 
 interface CarouselPaginationProps {
   currentImage: number
@@ -22,91 +16,50 @@ const CarouselPagination: React.FC<CarouselPaginationProps> = ({
   api,
   images,
 }) => {
+  const goTo = (index: number) => {
+    setCurrentImage(index)
+    api?.scrollTo(index)
+  }
+
   return (
-    <Pagination>
-      <PaginationContent>
-        <CustomButton
-          disabled={currentImage === 0}
-          onClick={() => {
-            setCurrentImage(0)
-            api?.scrollTo(0)
-          }}
-          size="sm"
-        >
-          <CustomButton.Icon>
-            <ChevronsLeft />
-          </CustomButton.Icon>
-        </CustomButton>
+    <div className="flex items-center justify-center gap-3">
+      <button
+        aria-label="Previous image"
+        className="text-mainColor transition-opacity hover:opacity-70 disabled:pointer-events-none disabled:opacity-30"
+        disabled={currentImage === 0}
+        onClick={() => goTo(currentImage - 1)}
+        type="button"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
 
-        <CustomButton
-          disabled={currentImage === 0}
-          onClick={() => {
-            setCurrentImage(currentImage - 1)
-            api?.scrollPrev()
-          }}
-          size="sm"
-        >
-          <CustomButton.Icon>
-            <ChevronLeft />
-          </CustomButton.Icon>
-        </CustomButton>
+      <div className="flex items-center gap-1.5">
+        {images.map((_, index) => (
+          <button
+            aria-label={`Go to image ${index + 1}`}
+            className={cn(
+              'h-1.5 rounded-full transition-all duration-200',
+              index === currentImage
+                ? 'w-4 bg-mainColor'
+                : 'w-1.5 bg-mainColor/30 hover:bg-mainColor/60'
+            )}
+            key={index}
+            onClick={() => goTo(index)}
+            type="button"
+          />
+        ))}
+      </div>
 
-        {currentImage > 0 && (
-          <CustomButton
-            onClick={() => {
-              setCurrentImage(currentImage - 1)
-              api?.scrollTo(currentImage - 1)
-            }}
-            size="sm"
-          >
-            <CustomButton.Label>{currentImage}</CustomButton.Label>
-          </CustomButton>
-        )}
-
-        <CustomButton disabled size="sm">
-          <CustomButton.Label>{currentImage + 1}</CustomButton.Label>
-        </CustomButton>
-
-        {currentImage < images.length - 1 && (
-          <CustomButton
-            onClick={() => {
-              setCurrentImage(currentImage + 1)
-              api?.scrollTo(currentImage + 1)
-            }}
-            size="sm"
-          >
-            <CustomButton.Label>{currentImage + 2}</CustomButton.Label>
-          </CustomButton>
-        )}
-
-        <CustomButton
-          disabled={currentImage === images.length - 1}
-          onClick={() => {
-            setCurrentImage(currentImage + 1)
-            api?.scrollNext()
-          }}
-          size="sm"
-        >
-          {' '}
-          <CustomButton.Icon>
-            <ChevronRight />
-          </CustomButton.Icon>
-        </CustomButton>
-
-        <CustomButton
-          disabled={currentImage === images.length - 1}
-          onClick={() => {
-            setCurrentImage(images.length - 1)
-            api?.scrollTo(images.length - 1)
-          }}
-          size="sm"
-        >
-          <CustomButton.Icon>
-            <ChevronsRight />
-          </CustomButton.Icon>
-        </CustomButton>
-      </PaginationContent>
-    </Pagination>
+      <button
+        aria-label="Next image"
+        className="text-mainColor transition-opacity hover:opacity-70 disabled:pointer-events-none disabled:opacity-30"
+        disabled={currentImage === images.length - 1}
+        onClick={() => goTo(currentImage + 1)}
+        type="button"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </div>
   )
 }
 

--- a/src/components/custom/custom-navbar.tsx
+++ b/src/components/custom/custom-navbar.tsx
@@ -18,6 +18,7 @@ import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
 import { useUser } from '@/hooks/use-user'
 import { formatPhoneNumber } from '@/lib/constants/format-number'
 import { cn } from '@/lib/utils/cn'
+import { getProjectSlug } from '@/lib/utils/project-slug'
 import LanguageToggle from '../toggles/LanguageToggle'
 import { ModeToggle } from '../toggles/ModeToggle'
 import { CustomButton } from './custom-button'
@@ -170,7 +171,11 @@ export function Navbar() {
           <ul className="grid w-[400px] gap-1 p-4 md:w-[500px] md:grid-cols-2 lg:w-[300px]">
             {project.map(({ title, description }) => {
               return (
-                <ListItem href="/projects?search=" key={title} title={title}>
+                <ListItem
+                  href={`/projects/${getProjectSlug(title)}`}
+                  key={title}
+                  title={title}
+                >
                   {description}
                 </ListItem>
               )

--- a/src/components/custom/desktop-frame.tsx
+++ b/src/components/custom/desktop-frame.tsx
@@ -10,15 +10,16 @@ export function DesktopFrame({ children, className }: DesktopFrameProps) {
   return (
     <div
       className={cn(
-        'relative mx-auto aspect-[16/9] w-full max-w-full overflow-hidden rounded-xl border-8 border-gray-800 bg-gray-900 shadow-lg dark:border-gray-200 dark:bg-gray-100',
+        'relative mx-auto flex aspect-video w-full max-w-full flex-col overflow-hidden rounded-xl border border-mainBorder bg-card shadow-lg transition-shadow duration-300 hover:shadow-xl dark:border-main-border-dark',
         className
       )}
     >
-      <div className="absolute inset-0 flex items-center justify-center">
-        {children}
+      <div className="flex h-6 shrink-0 items-center gap-1.5 border-mainBorder border-b bg-muted/60 px-3 dark:border-main-border-dark">
+        <span className="h-2 w-2 rounded-full bg-red-400/70" />
+        <span className="h-2 w-2 rounded-full bg-yellow-400/70" />
+        <span className="h-2 w-2 rounded-full bg-green-400/70" />
       </div>
-      {/* Monitor stand */}
-      <div className="absolute bottom-0 left-1/2 h-2 w-1/3 -translate-x-1/2 rounded-b-lg bg-gray-700 dark:bg-gray-300" />
+      <div className="relative flex-1 overflow-hidden">{children}</div>
     </div>
   )
 }

--- a/src/components/custom/phone-frame.tsx
+++ b/src/components/custom/phone-frame.tsx
@@ -1,27 +1,24 @@
+import type React from 'react'
+import { cn } from '@/lib/utils/cn'
+
 interface PhoneFrameProps {
   children: React.ReactNode
   className?: string
 }
 
-export default function PhoneFrame({
-  children,
-  className = '',
-}: PhoneFrameProps) {
+export default function PhoneFrame({ children, className }: PhoneFrameProps) {
   return (
-    <div className={`relative mx-auto my-5 ${className}`}>
-      <div className="relative flex h-[560px] w-[280px] flex-col items-center rounded-[36px] border border-[#333] bg-[#1a1a1a] p-3 shadow-lg sm:h-[640px] sm:w-[320px]">
-        <div className="relative mb-1 flex h-[25px] w-[120px] items-center justify-center gap-2 rounded-b-[16px] bg-[#1a1a1a]">
-          <div className="h-[5px] w-[40px] rounded-[3px] bg-[#333]" />
-
-          <div className="h-[8px] w-[8px] rounded-full bg-[#333]" />
-        </div>
-
-        <div className="w-full flex-grow overflow-hidden rounded-[24px] bg-white">
-          {children}
-        </div>
-
-        <div className="mt-2 h-[40px] w-[40px] rounded-full border-2 border-[#333]" />
+    <div
+      className={cn(
+        'relative mx-auto flex aspect-[9/19] h-[560px] max-h-full flex-col overflow-hidden rounded-[2rem] border border-mainBorder bg-card p-1.5 shadow-lg transition-shadow duration-300 hover:shadow-xl dark:border-main-border-dark',
+        className
+      )}
+    >
+      <div className="relative flex-1 overflow-hidden rounded-[1.5rem] bg-background">
+        <div className="absolute top-0 left-1/2 z-10 h-4 w-16 -translate-x-1/2 rounded-b-xl bg-card" />
+        {children}
       </div>
+      <div className="mx-auto mt-1.5 h-1 w-16 shrink-0 rounded-full bg-mainBorder dark:bg-main-border-dark" />
     </div>
   )
 }

--- a/src/components/custom/project-card.tsx
+++ b/src/components/custom/project-card.tsx
@@ -1,10 +1,5 @@
 'use client'
-import parse from 'html-react-parser'
-
 import {
-  ArrowRight,
-  Check,
-  Code,
   ExternalLink,
   GitBranch,
   Github,
@@ -14,41 +9,23 @@ import {
   Smartphone,
   Star,
 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { useTranslation } from 'react-i18next'
-import Typewriter from 'typewriter-effect'
 import TechnologyIcon from '@/components/Icon/TechnologyIcon'
 import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion'
-import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import {
-  Carousel,
-  type CarouselApi,
-  CarouselContent,
-  CarouselItem,
-} from '@/components/ui/carousel'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { getProjectSlug } from '@/lib/utils/project-slug'
 import { sortTechnologiesByFrequency } from '@/lib/utils/technology-utils'
 import type { ProjectType } from '@/types/ProjectType'
 import { Badge } from '../ui/badge'
-import CarouselPagination from './carousel-pagination'
 import { CustomBadge } from './custom-badge'
-import { CustomButton } from './custom-button'
 import { DesktopFrame } from './desktop-frame'
-import { ImageViewer } from './image-viewer'
 import PhoneFrame from './phone-frame'
 import Section from './section'
-import TechnologiesSection from './technology-section'
 
 interface ProjectCardProps {
   project: ProjectType
@@ -57,7 +34,6 @@ interface ProjectCardProps {
 
 export default function ProjectCard({
   project: {
-    about,
     description,
     technologies,
     title,
@@ -69,460 +45,114 @@ export default function ProjectCard({
     link,
     repositoryUrl,
     versions,
-    endsDate,
     isDeveloping,
-    startsDate,
     showEvolution,
-    features,
     thumbnail,
   },
   allProjects,
 }: ProjectCardProps) {
   const { t } = useTranslation()
-  const [currentImage, setCurrentImage] = useState(0)
-  const [api, setApi] = useState<CarouselApi>()
-  const [openAccordion, setOpenAccordion] = useState<string | undefined>(
-    undefined
-  )
-  const [selectedVersion, setSelectedVersion] = useState<string>(
-    versions ? String(versions?.length - 1) : '0'
-  )
 
   const sortedTechnologies = sortTechnologiesByFrequency(
     technologies,
     allProjects
   )
 
-  useEffect(() => {
-    const urlParams = new URLSearchParams(location.search)
-    const searchParam = urlParams.get('search') || ''
-    setOpenAccordion(searchParam)
-  }, [location.search])
-
-  useEffect(() => {
-    if (!api) return
-    setCurrentImage(api.selectedScrollSnap())
-    api.on('select', () => {
-      setCurrentImage(api.selectedScrollSnap())
-    })
-  }, [api])
-
   const previewImage = thumbnail || images?.[0]
 
   return (
-    <Card className="transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-1 hover:shadow-lg">
-      <Section.Root id={title}>
-        <Accordion
-          className="w-full"
-          collapsible
-          onValueChange={setOpenAccordion}
-          type="single"
-          value={openAccordion}
-        >
-          <AccordionItem className="border-none" value={title}>
-            <CardHeader className="pb-3">
-              <AccordionTrigger className="w-full p-0 hover:no-underline">
-                <div className="flex w-full flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-                  <div className="flex items-center gap-3">
-                    <div className="rounded-lg p-2">
-                      {isMobile ? (
-                        <Smartphone className="h-4 w-4 !text-mainColor" />
-                      ) : (
-                        <Monitor className="h-4 w-4 !text-mainColor" />
-                      )}
-                    </div>
-                    <div className="text-left">
-                      <div className="flex items-center gap-2">
-                        <CardTitle className="font-semibold text-foreground text-lg">
-                          <Typewriter
-                            onInit={typewriter => {
-                              typewriter.typeString(title).start()
-                            }}
-                          />
-                        </CardTitle>
-                        {favorite && (
-                          <Star className="h-4 w-4 fill-current text-yellow-400" />
-                        )}
-                        {showEvolution && versions && versions.length > 0 && (
-                          <GitBranch className="h-4 w-4 !text-mainColor" />
-                        )}
-                      </div>
-                      <div>
-                        <CardDescription>{description}</CardDescription>
-                      </div>
-
-                      {openAccordion !== title && (
-                        <div className="mt-2 flex flex-wrap gap-1">
-                          {sortedTechnologies.slice(0, 6).map(tech => (
-                            <div className="rounded p-1" key={tech}>
-                              <TechnologyIcon technology={tech} />
-                            </div>
-                          ))}
-                          {sortedTechnologies.length > 6 && (
-                            <CustomBadge>
-                              +{sortedTechnologies.length - 6}
-                            </CustomBadge>
-                          )}
-                        </div>
-                      )}
-                    </div>
+    <Link href={`/projects/${getProjectSlug(title)}`}>
+      <Card className="cursor-pointer transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-1 hover:shadow-lg">
+        <Section.Root id={title}>
+          <CardHeader className="pb-3">
+            <div className="flex w-full flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+              <div className="flex items-center gap-3">
+                <div className="rounded-lg p-2">
+                  {isMobile ? (
+                    <Smartphone className="h-4 w-4 !text-mainColor" />
+                  ) : (
+                    <Monitor className="h-4 w-4 !text-mainColor" />
+                  )}
+                </div>
+                <div className="text-left">
+                  <div className="flex items-center gap-2">
+                    <CardTitle className="font-semibold text-foreground text-lg">
+                      {title}
+                    </CardTitle>
+                    {favorite && (
+                      <Star className="h-4 w-4 fill-current text-yellow-400" />
+                    )}
+                    {showEvolution && versions && versions.length > 0 && (
+                      <GitBranch className="h-4 w-4 !text-mainColor" />
+                    )}
+                  </div>
+                  <div>
+                    <CardDescription>{description}</CardDescription>
                   </div>
 
-                  {openAccordion !== title && previewImage && (
-                    <div className="w-full px-6 pb-4 sm:w-auto sm:px-0 sm:pb-0">
-                      <div className="relative flex h-48 w-full items-center justify-center overflow-hidden rounded-md">
-                        {isMobile ? (
-                          <PhoneFrame className="h-full max-h-[180px]">
-                            <img
-                              alt={`Preview of ${title}`}
-                              className="h-full w-full object-cover"
-                              decoding="async"
-                              loading="lazy"
-                              src={previewImage || '/placeholder.svg'}
-                            />
-                          </PhoneFrame>
-                        ) : (
-                          <DesktopFrame className="h-full max-h-[180px]">
-                            <img
-                              alt={`Preview of ${title}`}
-                              className="h-full w-full object-contain"
-                              decoding="async"
-                              loading="lazy"
-                              src={previewImage || '/placeholder.svg'}
-                            />
-                          </DesktopFrame>
-                        )}
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {sortedTechnologies.slice(0, 6).map(tech => (
+                      <div className="rounded p-1" key={tech}>
+                        <TechnologyIcon technology={tech} />
                       </div>
-                    </div>
-                  )}
-                  <div className="flex items-center gap-2 sm:ml-auto">
-                    {isDeveloping && (
-                      <Badge className="flex items-center gap-1 border-green-300 bg-green-100 text-sm text-green-800 hover:bg-green-100 dark:bg-green-900 dark:text-green-300">
-                        <Settings className="h-4 w-4" />
-                        {t('projectCard.inDevelopment')}
-                      </Badge>
-                    )}
-                    {images && images.length > 0 && (
-                      <ImageIcon className="h-4 w-4 !text-mainColor" />
-                    )}
-                    {(repositoryUrl ||
-                      frontEndRepositoryUrl ||
-                      backEndRepositoryUrl) && (
-                      <Github className="h-4 w-4 !text-mainColor" />
-                    )}
-                    {link && (
-                      <ExternalLink className="h-4 w-4 !text-mainColor" />
+                    ))}
+                    {sortedTechnologies.length > 6 && (
+                      <CustomBadge>
+                        +{sortedTechnologies.length - 6}
+                      </CustomBadge>
                     )}
                   </div>
                 </div>
-              </AccordionTrigger>
-            </CardHeader>
-            <AccordionContent>
-              <CardContent>
-                <div className="space-y-6">
-                  <div className="rounded-lg space-y-2">
-                    <p className="text-foreground text-sm leading-relaxed">
-                      {about}
-                    </p>
-                    <div className="text-sm space-y-1">
-                      {startsDate && (
-                        <div>
-                          <span className="font-semibold text-mainColor">
-                            {t('about.start')}:
-                          </span>{' '}
-                          {startsDate}
-                        </div>
-                      )}
-                      {endsDate && (
-                        <div>
-                          <span className="font-semibold text-mainColor">
-                            {t('about.end')}:
-                          </span>{' '}
-                          {endsDate}
-                        </div>
-                      )}
-                    </div>
-                  </div>
+              </div>
 
-                  {features && features.length > 0 && (
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <Check className="h-4 w-4 !text-mainColor" />
-                        <h4 className="font-semibold text-foreground text-sm">
-                          {t('projectCard.features') || 'Features Principais'}
-                        </h4>
-                      </div>
-                      <ul className="grid gap-2 sm:grid-cols-2">
-                        {features.map((feature, index) => (
-                          <li
-                            className="flex items-start gap-2 text-sm text-muted-foreground"
-                            key={index}
-                          >
-                            <Check className="mt-0.5 h-4 w-4 flex-shrink-0 !text-mainColor" />
-                            <span>{parse(feature)}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-
-                  {showEvolution && versions && versions.length > 0 && (
-                    <div>
-                      <div className="mb-3 flex items-center gap-2">
-                        <GitBranch className="h-4 w-4 !text-mainColor" />
-                        <h4 className="font-semibold text-foreground text-sm">
-                          {t('projectEvolution')}
-                        </h4>
-                      </div>
-                      <Tabs
-                        onValueChange={setSelectedVersion}
-                        value={selectedVersion}
-                      >
-                        <TabsList
-                          className="grid w-full"
-                          style={{
-                            gridTemplateColumns: `repeat(${versions.length}, minmax(0, 1fr))`,
-                          }}
-                        >
-                          {versions
-                            .map((version, index) => (
-                              <TabsTrigger key={index} value={String(index)}>
-                                {version.name ?? `v${index + 1}`}
-                              </TabsTrigger>
-                            ))
-                            .reverse()}
-                        </TabsList>
-
-                        {versions
-                          .map((version, index) => (
-                            <TabsContent
-                              className="mt-4"
-                              key={index}
-                              value={String(index)}
-                            >
-                              <div className="space-y-4">
-                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                  <ArrowRight className="h-4 w-4" />
-                                  <span>
-                                    {version.description ||
-                                      `${version.name} do projeto`}
-                                  </span>
-                                </div>
-                                <TechnologiesSection
-                                  technologies={version.technologies}
-                                />
-                                {version.images &&
-                                  version.images.length > 0 && (
-                                    <div>
-                                      <div className="mb-3 flex items-center gap-2">
-                                        <ImageIcon className="h-4 w-4 !text-mainColor" />
-                                        <h4 className="font-semibold text-foreground text-sm">
-                                          {t('projectCard.images')}
-                                        </h4>
-                                      </div>
-                                      <Carousel setApi={setApi}>
-                                        <CarouselContent className="h-full w-[500px]">
-                                          {version.images?.map((image, i) =>
-                                            isMobile ? (
-                                              <CarouselItem
-                                                className="flex justify-center"
-                                                key={i}
-                                              >
-                                                <ImageViewer
-                                                  alt={`Screenshot ${i + 1}`}
-                                                  src={
-                                                    image || '/placeholder.svg'
-                                                  }
-                                                >
-                                                  <PhoneFrame>
-                                                    <img
-                                                      alt={`Screenshot ${i + 1}`}
-                                                      className="h-full w-full object-cover"
-                                                      decoding="async"
-                                                      loading="lazy"
-                                                      src={
-                                                        image ||
-                                                        '/placeholder.svg'
-                                                      }
-                                                    />
-                                                  </PhoneFrame>
-                                                </ImageViewer>
-                                              </CarouselItem>
-                                            ) : (
-                                              <CarouselItem key={i}>
-                                                <DesktopFrame>
-                                                  <ImageViewer
-                                                    alt={`Screenshot ${i + 1}`}
-                                                    src={
-                                                      image ||
-                                                      '/placeholder.svg'
-                                                    }
-                                                  >
-                                                    <img
-                                                      alt={`Screenshot ${i + 1}`}
-                                                      className="h-full w-full rounded-lg object-contain"
-                                                      decoding="async"
-                                                      loading="lazy"
-                                                      src={
-                                                        image ||
-                                                        '/placeholder.svg'
-                                                      }
-                                                    />
-                                                  </ImageViewer>
-                                                </DesktopFrame>
-                                              </CarouselItem>
-                                            )
-                                          )}
-                                        </CarouselContent>
-                                        <div className="py-2 text-center !text-mainColor text-xs dark:!text-mainColor">
-                                          {images && (
-                                            <CarouselPagination
-                                              api={api}
-                                              currentImage={currentImage}
-                                              images={images}
-                                              setCurrentImage={setCurrentImage}
-                                            />
-                                          )}
-                                        </div>
-                                      </Carousel>
-                                    </div>
-                                  )}
-                              </div>
-                            </TabsContent>
-                          ))
-                          .reverse()}
-                      </Tabs>
-                    </div>
-                  )}
-
-                  {!showEvolution || !versions || versions.length === 0 ? (
-                    <div>
-                      <div className="mb-3 flex items-center gap-2">
-                        <Code className="h-4 w-4 !text-mainColor" />
-                        <h4 className="font-semibold text-foreground text-sm">
-                          {t('projectCard.technologiesUsed')}
-                        </h4>
-                      </div>
-                      <TechnologiesSection technologies={sortedTechnologies} />
-                    </div>
-                  ) : null}
-
-                  {(!showEvolution || !versions || versions.length === 0) &&
-                  images ? (
-                    <div>
-                      <div className="mb-3 flex items-center gap-2">
-                        <ImageIcon className="h-4 w-4 !text-mainColor" />
-                        <h4 className="font-semibold text-foreground text-sm">
-                          {t('projectCard.images')}
-                        </h4>
-                      </div>
-                      <Carousel setApi={setApi}>
-                        <CarouselContent className="h-full w-[500px]">
-                          {images?.map((image, index) =>
-                            isMobile ? (
-                              <CarouselItem
-                                className="flex justify-center"
-                                key={index}
-                              >
-                                <ImageViewer
-                                  alt={`Screenshot ${index + 1}`}
-                                  src={image || '/placeholder.svg'}
-                                >
-                                  <PhoneFrame>
-                                    <img
-                                      alt={`Screenshot ${index + 1}`}
-                                      className="h-full w-full object-cover"
-                                      decoding="async"
-                                      loading="lazy"
-                                      src={image || '/placeholder.svg'}
-                                    />
-                                  </PhoneFrame>
-                                </ImageViewer>
-                              </CarouselItem>
-                            ) : (
-                              <CarouselItem key={index}>
-                                <DesktopFrame>
-                                  <ImageViewer
-                                    alt={`Screenshot ${index + 1}`}
-                                    src={image || '/placeholder.svg'}
-                                  >
-                                    <img
-                                      alt={`Screenshot ${index + 1}`}
-                                      className="h-full w-full rounded-lg object-contain"
-                                      decoding="async"
-                                      loading="lazy"
-                                      src={image || '/placeholder.svg'}
-                                    />
-                                  </ImageViewer>
-                                </DesktopFrame>
-                              </CarouselItem>
-                            )
-                          )}
-                        </CarouselContent>
-                        <div className="py-2 text-center !text-mainColor text-xs dark:!text-mainColor">
-                          {images && (
-                            <CarouselPagination
-                              api={api}
-                              currentImage={currentImage}
-                              images={images}
-                              setCurrentImage={setCurrentImage}
-                            />
-                          )}
-                        </div>
-                      </Carousel>
-                    </div>
-                  ) : null}
-
-                  <div className="flex flex-wrap items-center justify-center gap-3 border-mainBorder pt-4 dark:border-main-border-dark">
-                    {frontEndRepositoryUrl && (
-                      <CustomButton href={frontEndRepositoryUrl}>
-                        <CustomButton.Icon>
-                          <Github />
-                        </CustomButton.Icon>
-                        <CustomButton.Label>
-                          {' '}
-                          {t('projectCard.viewFrontEndRepo')}
-                        </CustomButton.Label>
-                      </CustomButton>
-                    )}
-                    {backEndRepositoryUrl && (
-                      <CustomButton href={backEndRepositoryUrl}>
-                        <CustomButton.Icon>
-                          <Github />
-                        </CustomButton.Icon>
-                        <CustomButton.Label>
-                          {t('projectCard.viewBackEndRepo')}
-                        </CustomButton.Label>
-                      </CustomButton>
-                    )}
-                    {!(frontEndRepositoryUrl || backEndRepositoryUrl) &&
-                      repositoryUrl && (
-                        <CustomButton href={repositoryUrl}>
-                          <CustomButton.Icon>
-                            <Github />
-                          </CustomButton.Icon>
-                          <CustomButton.Label>
-                            {t('projectCard.viewGitHub')}
-                          </CustomButton.Label>
-                        </CustomButton>
-                      )}
-                    {link && (
-                      <CustomButton href={link}>
-                        <CustomButton.Icon>
-                          <ExternalLink />
-                        </CustomButton.Icon>
-                        <CustomButton.Label>
-                          {t('projectCard.visitSite')}
-                        </CustomButton.Label>
-                      </CustomButton>
+              {previewImage && (
+                <div className="w-full px-6 pb-4 sm:w-auto sm:px-0 sm:pb-0">
+                  <div className="relative flex h-48 w-full items-center justify-center overflow-hidden rounded-md">
+                    {isMobile ? (
+                      <PhoneFrame className="h-full max-h-[180px]">
+                        <img
+                          alt={`Preview of ${title}`}
+                          className="h-full w-full object-cover"
+                          decoding="async"
+                          loading="lazy"
+                          src={previewImage || '/placeholder.svg'}
+                        />
+                      </PhoneFrame>
+                    ) : (
+                      <DesktopFrame className="h-full max-h-[180px]">
+                        <img
+                          alt={`Preview of ${title}`}
+                          className="h-full w-full object-contain"
+                          decoding="async"
+                          loading="lazy"
+                          src={previewImage || '/placeholder.svg'}
+                        />
+                      </DesktopFrame>
                     )}
                   </div>
                 </div>
-              </CardContent>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
-      </Section.Root>
-    </Card>
+              )}
+              <div className="flex items-center gap-2 sm:ml-auto">
+                {isDeveloping && (
+                  <Badge className="flex items-center gap-1 border-green-300 bg-green-100 text-sm text-green-800 hover:bg-green-100 dark:bg-green-900 dark:text-green-300">
+                    <Settings className="h-4 w-4" />
+                    {t('projectCard.inDevelopment')}
+                  </Badge>
+                )}
+                {images && images.length > 0 && (
+                  <ImageIcon className="h-4 w-4 !text-mainColor" />
+                )}
+                {(repositoryUrl ||
+                  frontEndRepositoryUrl ||
+                  backEndRepositoryUrl) && (
+                  <Github className="h-4 w-4 !text-mainColor" />
+                )}
+                {link && <ExternalLink className="h-4 w-4 !text-mainColor" />}
+              </div>
+            </div>
+          </CardHeader>
+        </Section.Root>
+      </Card>
+    </Link>
   )
 }

--- a/src/components/custom/project-details.tsx
+++ b/src/components/custom/project-details.tsx
@@ -1,0 +1,341 @@
+'use client'
+import parse from 'html-react-parser'
+
+import {
+  ArrowRight,
+  Check,
+  Code,
+  ExternalLink,
+  Github,
+  GitBranch,
+  ImageIcon,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Carousel,
+  type CarouselApi,
+  CarouselContent,
+  CarouselItem,
+} from '@/components/ui/carousel'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { sortTechnologiesByFrequency } from '@/lib/utils/technology-utils'
+import type { ProjectType } from '@/types/ProjectType'
+import CarouselPagination from './carousel-pagination'
+import { CustomButton } from './custom-button'
+import { DesktopFrame } from './desktop-frame'
+import { ImageViewer } from './image-viewer'
+import PhoneFrame from './phone-frame'
+import TechnologiesSection from './technology-section'
+
+interface ProjectDetailsProps {
+  project: ProjectType
+  allProjects: ProjectType[]
+}
+
+export function ProjectDetails({ project, allProjects }: ProjectDetailsProps) {
+  const {
+    about,
+    technologies,
+    backEndRepositoryUrl,
+    frontEndRepositoryUrl,
+    images,
+    isMobile,
+    link,
+    repositoryUrl,
+    versions,
+    endsDate,
+    startsDate,
+    showEvolution,
+    features,
+  } = project
+
+  const { t } = useTranslation()
+  const [currentImage, setCurrentImage] = useState(0)
+  const [api, setApi] = useState<CarouselApi>()
+  const [selectedVersion, setSelectedVersion] = useState<string>(
+    versions ? String(versions.length - 1) : '0'
+  )
+
+  const sortedTechnologies = sortTechnologiesByFrequency(
+    technologies,
+    allProjects
+  )
+
+  useEffect(() => {
+    if (!api) return
+    setCurrentImage(api.selectedScrollSnap())
+    api.on('select', () => {
+      setCurrentImage(api.selectedScrollSnap())
+    })
+  }, [api])
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg space-y-2">
+        <p className="text-foreground text-sm leading-relaxed">{about}</p>
+        <div className="text-sm space-y-1">
+          {startsDate && (
+            <div>
+              <span className="font-semibold text-mainColor">
+                {t('about.start')}:
+              </span>{' '}
+              {startsDate}
+            </div>
+          )}
+          {endsDate && (
+            <div>
+              <span className="font-semibold text-mainColor">
+                {t('about.end')}:
+              </span>{' '}
+              {endsDate}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {features && features.length > 0 && (
+        <div>
+          <div className="flex items-center gap-2">
+            <Check className="h-4 w-4 !text-mainColor" />
+            <h4 className="font-semibold text-foreground text-sm">
+              {t('projectCard.features') || 'Features Principais'}
+            </h4>
+          </div>
+          <ul className="grid gap-2 sm:grid-cols-2">
+            {features.map((feature, index) => (
+              <li
+                className="flex items-start gap-2 text-sm text-muted-foreground"
+                key={index}
+              >
+                <Check className="mt-0.5 h-4 w-4 flex-shrink-0 !text-mainColor" />
+                <span>{parse(feature)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {showEvolution && versions && versions.length > 0 && (
+        <div>
+          <div className="mb-3 flex items-center gap-2">
+            <GitBranch className="h-4 w-4 !text-mainColor" />
+            <h4 className="font-semibold text-foreground text-sm">
+              {t('projectEvolution')}
+            </h4>
+          </div>
+          <Tabs onValueChange={setSelectedVersion} value={selectedVersion}>
+            <TabsList
+              className="grid w-full"
+              style={{
+                gridTemplateColumns: `repeat(${versions.length}, minmax(0, 1fr))`,
+              }}
+            >
+              {versions
+                .map((version, index) => (
+                  <TabsTrigger key={index} value={String(index)}>
+                    {version.name ?? `v${index + 1}`}
+                  </TabsTrigger>
+                ))
+                .reverse()}
+            </TabsList>
+
+            {versions
+              .map((version, index) => (
+                <TabsContent className="mt-4" key={index} value={String(index)}>
+                  <div className="space-y-4">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <ArrowRight className="h-4 w-4" />
+                      <span>
+                        {version.description || `${version.name} do projeto`}
+                      </span>
+                    </div>
+                    <TechnologiesSection technologies={version.technologies} />
+                    {version.images && version.images.length > 0 && (
+                      <div>
+                        <div className="mb-3 flex items-center gap-2">
+                          <ImageIcon className="h-4 w-4 !text-mainColor" />
+                          <h4 className="font-semibold text-foreground text-sm">
+                            {t('projectCard.images')}
+                          </h4>
+                        </div>
+                        <Carousel setApi={setApi}>
+                          <CarouselContent className="h-full w-[500px]">
+                            {version.images?.map((image, i) =>
+                              isMobile ? (
+                                <CarouselItem
+                                  className="flex justify-center"
+                                  key={i}
+                                >
+                                  <ImageViewer
+                                    alt={`Screenshot ${i + 1}`}
+                                    src={image || '/placeholder.svg'}
+                                  >
+                                    <PhoneFrame>
+                                      <img
+                                        alt={`Screenshot ${i + 1}`}
+                                        className="h-full w-full object-cover"
+                                        decoding="async"
+                                        loading="lazy"
+                                        src={image || '/placeholder.svg'}
+                                      />
+                                    </PhoneFrame>
+                                  </ImageViewer>
+                                </CarouselItem>
+                              ) : (
+                                <CarouselItem key={i}>
+                                  <DesktopFrame>
+                                    <ImageViewer
+                                      alt={`Screenshot ${i + 1}`}
+                                      src={image || '/placeholder.svg'}
+                                    >
+                                      <img
+                                        alt={`Screenshot ${i + 1}`}
+                                        className="h-full w-full rounded-lg object-contain"
+                                        decoding="async"
+                                        loading="lazy"
+                                        src={image || '/placeholder.svg'}
+                                      />
+                                    </ImageViewer>
+                                  </DesktopFrame>
+                                </CarouselItem>
+                              )
+                            )}
+                          </CarouselContent>
+                          <div className="py-2 text-center !text-mainColor text-xs dark:!text-mainColor">
+                            {images && (
+                              <CarouselPagination
+                                api={api}
+                                currentImage={currentImage}
+                                images={images}
+                                setCurrentImage={setCurrentImage}
+                              />
+                            )}
+                          </div>
+                        </Carousel>
+                      </div>
+                    )}
+                  </div>
+                </TabsContent>
+              ))
+              .reverse()}
+          </Tabs>
+        </div>
+      )}
+
+      {!showEvolution || !versions || versions.length === 0 ? (
+        <div>
+          <div className="mb-3 flex items-center gap-2">
+            <Code className="h-4 w-4 !text-mainColor" />
+            <h4 className="font-semibold text-foreground text-sm">
+              {t('projectCard.technologiesUsed')}
+            </h4>
+          </div>
+          <TechnologiesSection technologies={sortedTechnologies} />
+        </div>
+      ) : null}
+
+      {(!showEvolution || !versions || versions.length === 0) && images ? (
+        <div>
+          <div className="mb-3 flex items-center gap-2">
+            <ImageIcon className="h-4 w-4 !text-mainColor" />
+            <h4 className="font-semibold text-foreground text-sm">
+              {t('projectCard.images')}
+            </h4>
+          </div>
+          <Carousel setApi={setApi}>
+            <CarouselContent className="h-full w-[500px]">
+              {images?.map((image, index) =>
+                isMobile ? (
+                  <CarouselItem className="flex justify-center" key={index}>
+                    <ImageViewer
+                      alt={`Screenshot ${index + 1}`}
+                      src={image || '/placeholder.svg'}
+                    >
+                      <PhoneFrame>
+                        <img
+                          alt={`Screenshot ${index + 1}`}
+                          className="h-full w-full object-cover"
+                          decoding="async"
+                          loading="lazy"
+                          src={image || '/placeholder.svg'}
+                        />
+                      </PhoneFrame>
+                    </ImageViewer>
+                  </CarouselItem>
+                ) : (
+                  <CarouselItem key={index}>
+                    <DesktopFrame>
+                      <ImageViewer
+                        alt={`Screenshot ${index + 1}`}
+                        src={image || '/placeholder.svg'}
+                      >
+                        <img
+                          alt={`Screenshot ${index + 1}`}
+                          className="h-full w-full rounded-lg object-contain"
+                          decoding="async"
+                          loading="lazy"
+                          src={image || '/placeholder.svg'}
+                        />
+                      </ImageViewer>
+                    </DesktopFrame>
+                  </CarouselItem>
+                )
+              )}
+            </CarouselContent>
+            <div className="py-2 text-center !text-mainColor text-xs dark:!text-mainColor">
+              {images && (
+                <CarouselPagination
+                  api={api}
+                  currentImage={currentImage}
+                  images={images}
+                  setCurrentImage={setCurrentImage}
+                />
+              )}
+            </div>
+          </Carousel>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center justify-center gap-3 border-mainBorder pt-4 dark:border-main-border-dark">
+        {frontEndRepositoryUrl && (
+          <CustomButton href={frontEndRepositoryUrl}>
+            <CustomButton.Icon>
+              <Github />
+            </CustomButton.Icon>
+            <CustomButton.Label>
+              {' '}
+              {t('projectCard.viewFrontEndRepo')}
+            </CustomButton.Label>
+          </CustomButton>
+        )}
+        {backEndRepositoryUrl && (
+          <CustomButton href={backEndRepositoryUrl}>
+            <CustomButton.Icon>
+              <Github />
+            </CustomButton.Icon>
+            <CustomButton.Label>
+              {t('projectCard.viewBackEndRepo')}
+            </CustomButton.Label>
+          </CustomButton>
+        )}
+        {!(frontEndRepositoryUrl || backEndRepositoryUrl) && repositoryUrl && (
+          <CustomButton href={repositoryUrl}>
+            <CustomButton.Icon>
+              <Github />
+            </CustomButton.Icon>
+            <CustomButton.Label>{t('projectCard.viewGitHub')}</CustomButton.Label>
+          </CustomButton>
+        )}
+        {link && (
+          <CustomButton href={link}>
+            <CustomButton.Icon>
+              <ExternalLink />
+            </CustomButton.Icon>
+            <CustomButton.Label>{t('projectCard.visitSite')}</CustomButton.Label>
+          </CustomButton>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/utils/project-slug.ts
+++ b/src/lib/utils/project-slug.ts
@@ -1,0 +1,17 @@
+import { projectsDataBr, projectsDataEn } from '@/data/projects-data'
+import { slugify } from './slugify'
+
+const slugsBr = projectsDataBr.map(project => slugify(project.title))
+const slugsEn = projectsDataEn.map(project => slugify(project.title))
+
+export function getProjectSlug(title: string): string {
+  return slugify(title)
+}
+
+export function getProjectIndexBySlug(slug: string): number {
+  const brIndex = slugsBr.indexOf(slug)
+  if (brIndex !== -1) {
+    return brIndex
+  }
+  return slugsEn.indexOf(slug)
+}

--- a/src/lib/utils/slugify.ts
+++ b/src/lib/utils/slugify.ts
@@ -1,0 +1,9 @@
+export function slugify(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}

--- a/src/views/ProjectDetail.tsx
+++ b/src/views/ProjectDetail.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import {
+  ArrowLeft,
+  ExternalLink,
+  GitBranch,
+  Github,
+  ImageIcon,
+  Monitor,
+  Settings,
+  Smartphone,
+  Star,
+} from 'lucide-react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { useTranslation } from 'react-i18next'
+import Container from '@/components/custom/container'
+import Sidebar from '@/components/custom/custom-sidebar'
+import Header from '@/components/custom/header'
+import { ProjectDetails } from '@/components/custom/project-details'
+import Section from '@/components/custom/section'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { useUser } from '@/hooks/use-user'
+import { getProjectIndexBySlug } from '@/lib/utils/project-slug'
+
+const EASE_OUT = [0.16, 1, 0.3, 1] as const
+
+interface ProjectDetailProps {
+  slug: string
+}
+
+export function ProjectDetail({ slug }: ProjectDetailProps) {
+  const { t } = useTranslation()
+  const { user } = useUser()
+
+  const index = getProjectIndexBySlug(slug)
+  if (index === -1) {
+    notFound()
+  }
+  const project = user.projects[index]
+
+  const {
+    title,
+    description,
+    favorite,
+    isMobile,
+    isDeveloping,
+    showEvolution,
+    versions,
+    images,
+    repositoryUrl,
+    frontEndRepositoryUrl,
+    backEndRepositoryUrl,
+    link,
+  } = project
+
+  return (
+    <div className="min-h-screen text-foreground">
+      <Sidebar />
+      <Container>
+        <Header />
+        <Section.Root>
+          <Link
+            className="mb-4 inline-flex items-center gap-2 text-sm text-mainColor hover:opacity-70"
+            href="/projects"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            {t('projects.backToProjects')}
+          </Link>
+          <motion.div
+            animate={{ opacity: 1, y: 0 }}
+            initial={{ opacity: 0, y: 20 }}
+            transition={{ duration: 0.5, ease: EASE_OUT }}
+          >
+            <Card>
+              <CardContent className="space-y-6 pt-6">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="rounded-lg p-2">
+                      {isMobile ? (
+                        <Smartphone className="h-5 w-5 !text-mainColor" />
+                      ) : (
+                        <Monitor className="h-5 w-5 !text-mainColor" />
+                      )}
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <h1 className="font-semibold text-foreground text-xl">
+                          {title}
+                        </h1>
+                        {favorite && (
+                          <Star className="h-4 w-4 fill-current text-yellow-400" />
+                        )}
+                        {showEvolution && versions && versions.length > 0 && (
+                          <GitBranch className="h-4 w-4 !text-mainColor" />
+                        )}
+                      </div>
+                      <p className="text-muted-foreground text-sm">
+                        {description}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {isDeveloping && (
+                      <Badge className="flex items-center gap-1 border-green-300 bg-green-100 text-sm text-green-800 hover:bg-green-100 dark:bg-green-900 dark:text-green-300">
+                        <Settings className="h-4 w-4" />
+                        {t('projectCard.inDevelopment')}
+                      </Badge>
+                    )}
+                    {images && images.length > 0 && (
+                      <ImageIcon className="h-4 w-4 !text-mainColor" />
+                    )}
+                    {(repositoryUrl ||
+                      frontEndRepositoryUrl ||
+                      backEndRepositoryUrl) && (
+                      <Github className="h-4 w-4 !text-mainColor" />
+                    )}
+                    {link && (
+                      <ExternalLink className="h-4 w-4 !text-mainColor" />
+                    )}
+                  </div>
+                </div>
+
+                <ProjectDetails allProjects={user.projects} project={project} />
+              </CardContent>
+            </Card>
+          </motion.div>
+        </Section.Root>
+      </Container>
+    </div>
+  )
+}

--- a/src/views/Projects.tsx
+++ b/src/views/Projects.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { motion } from 'framer-motion'
 import {
   ExternalLink,
   Filter,
@@ -15,7 +16,7 @@ import {
 } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import type React from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Container from '@/components/custom/container'
 import { CustomBadge } from '@/components/custom/custom-badge'
@@ -38,10 +39,16 @@ import { useUser } from '@/hooks/use-user'
 import { getTechnologyData } from '@/lib/utils/getTechnologyData'
 import type { ProjectType } from '@/types/ProjectType'
 
+const INITIAL_VISIBLE = 6
+const LOAD_STEP = 6
+const EASE_OUT = [0.16, 1, 0.3, 1] as const
+
 export const Projects: React.FC = () => {
   const { t, i18n } = useTranslation()
   const searchParams = useSearchParams()
   const [filteredProjects, setFilteredProjects] = useState<ProjectType[]>([])
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE)
+  const sentinelRef = useRef<HTMLDivElement>(null)
   const [filter, setFilter] = useState({
     selectedTechnologies: [] as string[],
     hasImage: false,
@@ -142,7 +149,39 @@ export const Projects: React.FC = () => {
       )
     })
     setFilteredProjects(filtered)
+    setVisibleCount(INITIAL_VISIBLE)
   }, [filter, user.projects])
+
+  useEffect(() => {
+    const node = sentinelRef.current
+    if (!node) {
+      return
+    }
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting) {
+          setVisibleCount(prev =>
+            Math.min(prev + LOAD_STEP, filteredProjects.length)
+          )
+        }
+      },
+      { rootMargin: '200px' }
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [filteredProjects.length])
+
+  const visibleProjects = filteredProjects.slice(0, visibleCount)
+
+  const reveal = (index: number) => ({
+    initial: { opacity: 0, y: 20 },
+    animate: { opacity: 1, y: 0 },
+    transition: {
+      duration: 0.4,
+      delay: Math.min(index * 0.06, 0.3),
+      ease: EASE_OUT,
+    },
+  })
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const searchValue = e.target.value
@@ -424,13 +463,19 @@ export const Projects: React.FC = () => {
               </Card>
               <div className="space-y-4">
                 {filteredProjects.length > 0 ? (
-                  filteredProjects.map(project => (
-                    <ProjectCard
-                      allProjects={user.projects}
-                      key={project.title}
-                      project={project}
-                    />
-                  ))
+                  <>
+                    {visibleProjects.map((project, index) => (
+                      <motion.div key={project.title} {...reveal(index)}>
+                        <ProjectCard
+                          allProjects={user.projects}
+                          project={project}
+                        />
+                      </motion.div>
+                    ))}
+                    {visibleCount < filteredProjects.length && (
+                      <div className="h-1 w-full" ref={sentinelRef} />
+                    )}
+                  </>
                 ) : (
                   <Card className="border-mainBorder dark:border-main-border-dark">
                     <CardContent className="pt-6">


### PR DESCRIPTION
## Summary
- `/projects` now reveals cards incrementally (IntersectionObserver, 6 initially, +6 per scroll) instead of rendering the full ~25-item filtered list at once.
- Clicking a project card navigates to a dedicated `/projects/[slug]` page showing everything about it (about, dates, features, version tabs + carousels, or plain tech + images carousel, link buttons) — previously this only appeared inline via an expandable accordion on the list page.
- `project-card.tsx` is now a lightweight, always-collapsed list item; the old accordion-content body was extracted into a new `ProjectDetails` component, reused by the detail page.
- Slugs are derived from project titles at runtime (`slugify`/`getProjectSlug`/`getProjectIndexBySlug` in `src/lib/utils/`) — no changes to the 2000-line project data file, and slugs resolve correctly regardless of which language (PT/EN) is active.
- Invalid slugs render a styled not-found page (`src/app/projects/[slug]/not-found.tsx`) with a link back to `/projects`.
- Fixed a pre-existing bug in the "Projects" nav dropdown: its 4 links pointed at `/projects?search=` with no search term ever filled in (dead link); they now go straight to each project's detail page.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run build` — compiles, `/projects/[slug]` registered as a dynamic route
- [x] Playwright: `/projects` shows 6 cards, scroll loads more (12 after one scroll), filtering resets the count
- [x] Playwright: clicking a card lands on `/projects/[slug]` with full detail matching the old accordion content (about, features, tech, image carousel, links)
- [x] Playwright: invalid slug returns HTTP 404 with the not-found page copy
- [x] Visual check (light/dark) of list and detail pages — no layout regressions
- [x] No console/page errors on `/projects` or a detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)